### PR TITLE
fix(ZN-389): branch name validation

### DIFF
--- a/.validate-branch-namerc.js
+++ b/.validate-branch-namerc.js
@@ -1,7 +1,7 @@
-const pattern = '^(feature|improvement|bugfix|hotfix|release)/[a-zA-Z0-9_.-]+$';
+const commitizenTypes = ['build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test'];
+const pattern = `^(${commitizenTypes.join('|')})[/a-zA-Z0-9_.-]+$`;
 
 module.exports = {
   pattern,
-  errorMsg:
-    `There is something wrong with your branch name. Branch names in this project must adhere to this contract: ${pattern}. Your commit will be rejected. You should rename your branch to a valid name and try again.`,
+  errorMsg: `There is something wrong with your branch name. Branch names in this project must adhere to this contract: ${pattern}. Your commit will be rejected. You should rename your branch to a valid name and try again.`,
 };


### PR DESCRIPTION
This PR fixes issue with branch name validation, now it is allowed to have more things after slash so it matches the pattern:
`commitizen-type/ticket-no/description` for example `fix/ZN-389/branch-name-validation`.

Description is optional, you can do `fix/ZN-389`.

It also adds consistency between branch name rules and commit rules, now the possible types are:
```
const commitizenTypes = ['build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test'];
```