### PR TITLE
fix: next page param

### DIFF
--- a/src/hooks/useUsers/useUsers.ts
+++ b/src/hooks/useUsers/useUsers.ts
@@ -12,9 +12,6 @@ export const useUsers = (options?: UseInfiniteQueryOptions<UsersInfiniteQueryArg
       count: 5,
     },
     getNextPageParam: (lastPage) => {
-      if (lastPage.nextPage === null) {
-        return false;
-      }
-      return lastPage.nextPage;
+      return lastPage.nextPage ?? undefined;
     },
   });


### PR DESCRIPTION
According to [infinite query documentation](https://tanstack.com/query/v4/docs/guides/infinite-queries)
`A hasNextPage boolean is now available and is true if getNextPageParam returns a value other than undefined`