### PR TITLE
chore(ZN-482): bump node version from 14 to 16

### DIFF
--- a/.changeset/plenty-ants-yell.md
+++ b/.changeset/plenty-ants-yell.md
@@ -1,0 +1,6 @@
+---
+'react-starter-boilerplate': minor
+---
+
+bump node version from 14 to 16
+bump `tshio/awscli-docker-compose-pipelines` img version from `0.0.3` to `0.0.5`

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -6,10 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 14.20.1
-        uses: actions/setup-node@v1
+      - name: Setup Node.js 16
+        uses: actions/setup-node@v3
         with:
-          node-version: 14.20.1
+          node-version: 16
       - name: Copy envs
         run: cp .env.dist .env
       - name: Install root dependencies

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -14,10 +14,10 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
-      - name: Use Node.js 14.20.1
-        uses: actions/setup-node@v1
+      - name: Setup Node.js 16
+        uses: actions/setup-node@v3
         with:
-          node-version: 14.20.1
+          node-version: 16
       - name: Install dependencies
         run: npm ci
       - name: Build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -162,7 +162,7 @@ deploy_to_staging:
   stage: deploy
   environment: staging
   image:
-    name: tshio/awscli-docker-compose-pipelines:0.0.3
+    name: tshio/awscli-docker-compose-pipelines:0.0.5
     entrypoint: ['']
   script:
     - npm ci

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -4,7 +4,7 @@ definitions:
     npm: $HOME/.npm
   steps:
     - step: &deploy-s3
-        image: tshio/awscli-docker-compose-pipelines:0.0.3
+        image: tshio/awscli-docker-compose-pipelines:0.0.5
         script:
           - npm ci
           - npm run build
@@ -14,7 +14,7 @@ definitions:
 pipelines:
   default:
     - step:
-        image: node:14.20.1
+        image: node:16.16.0
         caches:
           - node
           - npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,9 @@
         "vite-tsconfig-paths": "4.1.0",
         "vitest": "0.30.0",
         "wait-on": "7.0.1"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "react-starter-boilerplate",
   "version": "0.1.1",
   "private": true,
+  "engines": {
+    "node": ">=16"
+  },
   "scripts": {
     "start": "vite",
     "build": "tsc && vite build",


### PR DESCRIPTION
### Changelog

- bump node version from 14 to 16
- bump `tshio/awscli-docker-compose-pipelines` from `0.0.3` to `0.0.5` 
