### PR TITLE
fix: Improve useInifiteQuery hook typing

### DIFF
--- a/.changeset/rotten-frogs-mate.md
+++ b/.changeset/rotten-frogs-mate.md
@@ -1,0 +1,5 @@
+---
+'react-starter-boilerplate': patch
+---
+
+fix: Improve useInfiniteQuery hook typing

--- a/src/api/actions/index.ts
+++ b/src/api/actions/index.ts
@@ -7,6 +7,8 @@ export const queries = {
 
 export type AxiosQueriesType = typeof queries;
 
+export type AxiosInfiniteQueriesType = Pick<AxiosQueriesType, 'getUsersInfinite'>;
+
 export const mutations = {
   ...authMutations,
 } as const;

--- a/src/hooks/useInfiniteQuery/useInfiniteQuery.ts
+++ b/src/hooks/useInfiniteQuery/useInfiniteQuery.ts
@@ -8,7 +8,7 @@ import {
 } from '@tanstack/react-query';
 
 import { useApiClient } from 'hooks/useApiClient/useApiClient';
-import { AxiosQueriesType, queries } from 'api/actions';
+import { AxiosInfiniteQueriesType, queries } from 'api/actions';
 import { DataForQuery, GetQueryParams } from 'api/types/types';
 
 /**
@@ -17,7 +17,7 @@ import { DataForQuery, GetQueryParams } from 'api/types/types';
  * This hook uses proper querying strategy provided via ApiClientContext
  * @see ApiClientContextController.ts
  * */
-export const useInfiniteQuery = <Key extends keyof AxiosQueriesType, TError = unknown>(
+export const useInfiniteQuery = <Key extends keyof AxiosInfiniteQueriesType, TError = unknown>(
   query: Key,
   args?: GetQueryParams<Key>,
   options?: UseInfiniteQueryOptions<DataForQuery<Key>, TError>,


### PR DESCRIPTION
Hi guys! 🙂 I'm sending a proposal for improvement to the common issue I had using the `react-starter-boilerplate` project. 

### Problem

The problem is with the `useInfiteQuery` hook. As soon as I add some API action that contains at least one mandatory field, this hook throws an error 😕 

Example API action:
```
export type GetUserPayload = {
  id: string;
};

getUser: (client: AxiosInstance) => async({ id }: GetUserPayload) => {
  return (await client.get<GetUserResponse>(`/users/${id}`)).data;
}
```

Error thrown by hook:
```
src/hooks/useInfiniteQuery/useInfiniteQuery.ts:31:68 - error TS2345: Argument of type '{ pageParam: string | undefined; }' is not assignable to parameter of type 'GetUsersInfiniteArgs & GetUsersListArgs & { id: string; }'.
  Property 'id' is missing in type '{ pageParam: string | undefined; }' but required in type '{ id: string; }'.

31     async ({ pageParam }: { pageParam?: string }) => await queryFn({ pageParam, ...(args || {}) }),
```

### Suggested solution

The solution for this error is simple and it brings a lot of benefits 🙂 What I did was create a special type called `AxiosInfiniteQueriesType` in the API action index file. Then I used this type instead of `AxiosQueriesType` in the `useInfiteQuery` hook.

```
export type AxiosInfiniteQueriesType = Pick<AxiosQueriesType, 'getUsersInfinite'>;
```

If you take a closer look on `AxiosInfiniteQueriesType` type, it restricts the `AxiosQueriesType` to only API actions on which an "infinite query" can be executed. Then we have more control over which queries are "infinite queries" and only those queries can be run later using the `useInfiteQuery` hook.

Please take a look on my solution and let me know what you think about it 😉