### PR TITLE
feat: add new utils for handling translations

### DIFF
--- a/.changeset/polite-moons-lie.md
+++ b/.changeset/polite-moons-lie.md
@@ -1,0 +1,5 @@
+---
+'react-starter-boilerplate': patch
+---
+
+feat: Add new utils for handling translations in application

--- a/src/app/home/Home.tsx
+++ b/src/app/home/Home.tsx
@@ -1,16 +1,16 @@
 import { Fragment } from 'react';
 
-import { useLocale } from 'hooks/useLocale/useLocale';
-import { AppLocale } from 'context/locale/AppLocale.enum';
-import { AppMessages } from 'i18n/messages';
-import { LocationInfo } from 'ui/locationInfo/LocationInfo';
-import { useAuth } from 'hooks/useAuth/useAuth';
-import { useUsers } from '../../hooks/useUsers/useUsers';
 import { AppRoute } from 'routing/AppRoute.enum';
+import { AppLocale } from 'context/locale/AppLocale.enum';
+import { useLocale } from 'hooks/useLocale/useLocale';
+import { useAuth } from 'hooks/useAuth/useAuth';
+import { useUsers } from 'hooks/useUsers/useUsers';
 import { useNavigate } from 'hooks/useNavigate/useNavigate';
+import { Translation } from 'ui/translation/Translation';
+import { LocationInfo } from 'ui/locationInfo/LocationInfo';
 
 export const Home = () => {
-  const { formatMessage, locale, setLocale } = useLocale();
+  const { locale, setLocale } = useLocale();
   const { user, login, logout, isAuthenticated, isAuthenticating } = useAuth();
 
   const {
@@ -28,13 +28,12 @@ export const Home = () => {
     <>
       <h2>Home</h2>
       <p>
-        {formatMessage({ id: AppMessages['home.helloWorld'] })}
+        <Translation id="home.helloWorld" />
         <span style={{ margin: '0 1rem' }}>&#x2190;</span>
-        This text is translated using{' '}
-        <a href="https://github.com/formatjs/react-intl/blob/master/docs/API.md#formatmessage">
-          <code>formatMessage</code>
-        </a>{' '}
-        function from <a href="https://github.com/formatjs/react-intl">react-intl</a>. Click{' '}
+        <span>
+          This text is translated using <strong>Translation</strong> component.
+        </span>
+        <span>Click </span>
         <button
           style={{ fontSize: 'inherit' }}
           onClick={() => setLocale(locale === AppLocale.pl ? AppLocale.en : AppLocale.pl)}

--- a/src/hooks/useLocale/useLocale.ts
+++ b/src/hooks/useLocale/useLocale.ts
@@ -1,10 +1,12 @@
-import { useContext, useMemo } from 'react';
-import { IntlShape, useIntl } from 'react-intl';
+import { useContext, useCallback, useMemo } from 'react';
+import { useIntl } from 'react-intl';
 
+import type { TranslateFn } from 'i18n/messages';
 import { LocaleContext } from 'context/locale/localeContext/LocaleContext';
-import { LocaleContextValueType } from 'context/locale/localeContext/LocaleContext.types';
 
-export const useLocale = (): IntlShape & LocaleContextValueType => {
+import { UseLocaleReturnType } from './useLocale.types';
+
+export const useLocale: UseLocaleReturnType = () => {
   const intl = useIntl();
   const localeContext = useContext(LocaleContext);
 
@@ -12,13 +14,14 @@ export const useLocale = (): IntlShape & LocaleContextValueType => {
     throw new Error('LocaleContext is unavailable, make sure you are using LocaleContextController');
   }
 
-  const locale = useMemo(
+  const t: TranslateFn = useCallback((id, value?) => intl.formatMessage({ id }, value), [intl]);
+
+  return useMemo(
     () => ({
       ...intl,
       ...localeContext,
+      t,
     }),
-    [intl, localeContext],
+    [intl, localeContext, t],
   );
-
-  return locale;
 };

--- a/src/hooks/useLocale/useLocale.types.ts
+++ b/src/hooks/useLocale/useLocale.types.ts
@@ -1,0 +1,10 @@
+import type { IntlShape } from 'react-intl';
+
+import type { TranslateFn } from 'i18n/messages';
+import type { LocaleContextValueType } from 'context/locale/localeContext/LocaleContext.types';
+
+export type WithTranslateFn = {
+  t: TranslateFn;
+};
+
+export type UseLocaleReturnType = () => IntlShape & LocaleContextValueType & WithTranslateFn;

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1,3 +1,5 @@
+import type { PrimitiveType } from 'intl-messageformat/src/formatters';
+
 import { AppLocale } from 'context/locale/AppLocale.enum';
 
 import enMessages from './data/en.json';
@@ -5,22 +7,25 @@ import plMessages from './data/pl.json';
 
 type KeyAsValue<T> = { [P in keyof T]: P };
 
-const keysToValues = <T extends Record<string, string | unknown>>(source: T): KeyAsValue<typeof source> => {
-  return (Object.keys(source) as Array<keyof T>).reduce(
+const keysToValues = <T extends Record<string, string | unknown>>(source: T): KeyAsValue<typeof source> =>
+  (Object.keys(source) as Array<keyof T>).reduce(
     (accumulated, current) => {
       accumulated[current] = current;
       return accumulated;
     },
     {} as KeyAsValue<typeof source>,
   );
-};
 
 export const AppMessages = {
   ...keysToValues(enMessages),
   ...keysToValues(plMessages),
 };
 
-export const translations: Record<AppLocale, Record<keyof typeof AppMessages, string>> = {
+export type Translation = keyof typeof AppMessages;
+
+export type TranslateFn = (id: Translation, value?: Record<string, PrimitiveType>) => string;
+
+export const translations: Record<AppLocale, Record<Translation, string>> = {
   [AppLocale.en]: enMessages,
   [AppLocale.pl]: plMessages,
 };

--- a/src/ui/translation/Translation.tsx
+++ b/src/ui/translation/Translation.tsx
@@ -1,0 +1,10 @@
+import { useLocale } from 'hooks/useLocale/useLocale';
+import { AppMessages } from 'i18n/messages';
+
+import { TranslationProps } from './Translation.types';
+
+export const Translation = ({ id, values }: TranslationProps) => {
+  const { formatMessage } = useLocale();
+
+  return <>{formatMessage({ id: AppMessages[id] }, values)}</>;
+};

--- a/src/ui/translation/Translation.types.ts
+++ b/src/ui/translation/Translation.types.ts
@@ -1,0 +1,8 @@
+import { PrimitiveType } from 'react-intl';
+
+import { Translation } from 'i18n/messages';
+
+export type TranslationProps = {
+  id: Translation;
+  values?: Record<string, PrimitiveType>;
+};


### PR DESCRIPTION
Hi guys! I've added a few fancy utils for handling translations:
- `Translation` component that takes the translation ID and the values object as parameters and displays translations in the language currently selected in the system.
- `t` function in `useLocale` hook which is a more convenient variant of using the `formatMessage` function without importing the `AppMessages` object every time. Please take a look at the example below:

_`formatMessage` function:_
```
formatMessage({ id: AppMessages['home.helloWorld'] }, { label: 'value' })
```

_`t` function:_
```
t('home.helloWorld', { label: 'value' })
```