### PR TITLE
feat: add interface for logger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "react-starter-boilerplate",
       "version": "0.2.0",
       "dependencies": {
-        "@sentry/browser": "7.68.0",
+        "@sentry/browser": "7.109.0",
+        "@sentry/integrations": "7.109.0",
         "@tanstack/react-query": "4.36.1",
         "@tanstack/react-query-devtools": "4.35.0",
         "axios": "1.5.0",
@@ -2260,71 +2261,117 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@sentry-internal/tracing": {
-      "version": "7.68.0",
-      "license": "MIT",
+    "node_modules/@sentry-internal/feedback": {
+      "version": "7.109.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.109.0.tgz",
+      "integrity": "sha512-EL7N++poxvJP9rYvh6vSu24tsKkOveNCcCj4IM7+irWPjsuD2GLYYlhp/A/Mtt9l7iqO4plvtiQU5HGk7smcTQ==",
       "dependencies": {
-        "@sentry/core": "7.68.0",
-        "@sentry/types": "7.68.0",
-        "@sentry/utils": "7.68.0",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry/core": "7.109.0",
+        "@sentry/types": "7.109.0",
+        "@sentry/utils": "7.109.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "7.109.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.109.0.tgz",
+      "integrity": "sha512-Lh/K60kmloR6lkPUcQP0iamw7B/MdEUEx/ImAx4tUSMrLj+IoUEcq/ECgnnVyQkJq59+8nPEKrVLt7x6PUPEjw==",
+      "dependencies": {
+        "@sentry/core": "7.109.0",
+        "@sentry/replay": "7.109.0",
+        "@sentry/types": "7.109.0",
+        "@sentry/utils": "7.109.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry-internal/tracing": {
+      "version": "7.109.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.109.0.tgz",
+      "integrity": "sha512-PzK/joC5tCuh2R/PRh+7dp+uuZl7pTsBIjPhVZHMTtb9+ls65WkdZJ1/uKXPouyz8NOo9Xok7aEvEo9seongyw==",
+      "dependencies": {
+        "@sentry/core": "7.109.0",
+        "@sentry/types": "7.109.0",
+        "@sentry/utils": "7.109.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "7.68.0",
-      "license": "MIT",
+      "version": "7.109.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.109.0.tgz",
+      "integrity": "sha512-yx+OFG+Ab9qUDDgV9ZDv8M9O9Mqr0fjKta/LMlWALYLjzkMvxsPlRPFj7oMBlHqOTVLDeg7lFYmsA8wyWQ8Z8g==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.68.0",
-        "@sentry/core": "7.68.0",
-        "@sentry/replay": "7.68.0",
-        "@sentry/types": "7.68.0",
-        "@sentry/utils": "7.68.0",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry-internal/feedback": "7.109.0",
+        "@sentry-internal/replay-canvas": "7.109.0",
+        "@sentry-internal/tracing": "7.109.0",
+        "@sentry/core": "7.109.0",
+        "@sentry/replay": "7.109.0",
+        "@sentry/types": "7.109.0",
+        "@sentry/utils": "7.109.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.68.0",
-      "license": "MIT",
+      "version": "7.109.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.109.0.tgz",
+      "integrity": "sha512-xwD4U0IlvvlE/x/g/W1I8b4Cfb16SsCMmiEuBf6XxvAa3OfWBxKoqLifb3GyrbxMC4LbIIZCN/SvLlnGJPgszA==",
       "dependencies": {
-        "@sentry/types": "7.68.0",
-        "@sentry/utils": "7.68.0",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry/types": "7.109.0",
+        "@sentry/utils": "7.109.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/integrations": {
+      "version": "7.109.0",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.109.0.tgz",
+      "integrity": "sha512-8GwPFlUu4rB1Dx3e9tc3gCMmzC5Bd5lzThhg3tMBmzCCEp7UeA4u7eUuKJ5g49vjdznPDRG2p3PcRsApFZNPSg==",
+      "dependencies": {
+        "@sentry/core": "7.109.0",
+        "@sentry/types": "7.109.0",
+        "@sentry/utils": "7.109.0",
+        "localforage": "^1.8.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "7.68.0",
-      "license": "MIT",
+      "version": "7.109.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.109.0.tgz",
+      "integrity": "sha512-hCDjbTNO7ErW/XsaBXlyHFsUhneyBUdTec1Swf98TFEfVqNsTs6q338aUcaR8dGRLbLrJ9YU9D1qKq++v5h2CA==",
       "dependencies": {
-        "@sentry/core": "7.68.0",
-        "@sentry/types": "7.68.0",
-        "@sentry/utils": "7.68.0"
+        "@sentry-internal/tracing": "7.109.0",
+        "@sentry/core": "7.109.0",
+        "@sentry/types": "7.109.0",
+        "@sentry/utils": "7.109.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "7.68.0",
-      "license": "MIT",
+      "version": "7.109.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.109.0.tgz",
+      "integrity": "sha512-egCBnDv3YpVFoNzRLdP0soVrxVLCQ+rovREKJ1sw3rA2/MFH9WJ+DZZexsX89yeAFzy1IFsCp7/dEqudusml6g==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.68.0",
-      "license": "MIT",
+      "version": "7.109.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.109.0.tgz",
+      "integrity": "sha512-3RjxMOLMBwZ5VSiH84+o/3NY2An4Zldjz0EbfEQNRY9yffRiCPJSQiCJID8EoylCFOh/PAhPimBhqbtWJxX6iw==",
       "dependencies": {
-        "@sentry/types": "7.68.0",
-        "tslib": "^2.4.1 || ^1.9.3"
+        "@sentry/types": "7.109.0"
       },
       "engines": {
         "node": ">=8"
@@ -7812,6 +7859,11 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "dev": true,
@@ -9174,6 +9226,14 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/liftoff": {
       "version": "4.0.0",
       "dev": true,
@@ -9534,6 +9594,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "dependencies": {
+        "lie": "3.1.1"
       }
     },
     "node_modules/locate-path": {
@@ -13622,6 +13690,7 @@
     },
     "node_modules/tslib": {
       "version": "1.14.1",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsutils": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     ]
   },
   "dependencies": {
-    "@sentry/browser": "7.68.0",
+    "@sentry/browser": "7.109.0",
+    "@sentry/integrations": "7.109.0",
     "@tanstack/react-query": "4.36.1",
     "@tanstack/react-query-devtools": "4.35.0",
     "axios": "1.5.0",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,18 +1,18 @@
 import './wdyr';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import * as Sentry from '@sentry/browser';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
-import 'assets/styles/main.css';
 
+import 'assets/styles/main.css';
 import { AppProviders } from 'providers/AppProviders';
 import { AppRoutes } from 'routing/AppRoutes';
 import { enableMocking } from 'setupMSW';
+import { logger } from 'integrations/logger';
 
 const openReactQueryDevtools = import.meta.env.DEV;
 
 if (import.meta.env.VITE_SENTRY_DSN) {
-  Sentry.init({ dsn: import.meta.env.VITE_SENTRY_DSN });
+  logger.init();
 }
 
 const container = document.getElementById('root');

--- a/src/integrations/logger.ts
+++ b/src/integrations/logger.ts
@@ -1,0 +1,33 @@
+import { init, captureException, captureMessage, browserTracingIntegration } from '@sentry/browser';
+import { httpClientIntegration, captureConsoleIntegration } from '@sentry/integrations';
+
+type LogLevel = 'error' | 'info' | 'warning';
+type Logger = Record<LogLevel, (message: string | Error) => void> & Record<string, unknown>;
+
+const initLogger = () =>
+  init({
+    dsn: import.meta.env.VITE_SENTRY_DSN,
+    integrations: [
+      httpClientIntegration({
+        failedRequestStatusCodes: [[400, 599]],
+        failedRequestTargets: [/.*/],
+      }),
+      captureConsoleIntegration(),
+      browserTracingIntegration(),
+    ],
+    tracesSampleRate: 1.0,
+  });
+
+const sendLog = (level: LogLevel, message: string | Error) => {
+  if (typeof message === 'string') {
+    captureMessage(message, { level });
+  }
+  captureException(message, { level });
+};
+
+export const logger = {
+  init: initLogger,
+  error: (message: string | Error) => sendLog('error', message),
+  warning: (message: string | Error) => sendLog('warning', message),
+  info: (message: string | Error) => sendLog('info', message),
+} satisfies Logger;


### PR DESCRIPTION
Simpler logger implementation from PR: https://github.com/TheSoftwareHouse/react-starter-boilerplate/pull/62

I added a simple module with logger implementation. I didn't use class as this would be a singleton anyway. I thought this way it will be easier to understand and modify to meet any special needs.

There is no ContextProvider as logger does not depend on React nor needs to live in React lifecycle. This will simplify it's usage as we can simply import `logger` without any custom hooks, and can be used outside React if needed.