### PR TITLE
feat: add ErrorBoundary component

### DIFF
--- a/.changeset/empty-bottles-fold.md
+++ b/.changeset/empty-bottles-fold.md
@@ -1,0 +1,5 @@
+---
+'react-starter-boilerplate': minor
+---
+
+add ErrorBoundary component

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "qs": "6.12.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-error-boundary": "4.0.13",
         "react-intl": "6.6.5",
         "react-router-dom": "6.22.3",
         "typescript": "5.4.3"
@@ -468,7 +469,7 @@
       "version": "7.24.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
       "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -13138,6 +13139,17 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-error-boundary": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.13.tgz",
+      "integrity": "sha512-b6PwbdSv8XeOSYvjt8LpgpKrZ0yGdtZokYwkwV2wlcZbxgopHX/hgPl5VgpnoVOWd868n1hktM8Qm4b+02MiLQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
     "node_modules/react-intl": {
       "version": "6.6.5",
       "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.6.5.tgz",
@@ -13476,7 +13488,7 @@
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true
+      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.2",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "qs": "6.12.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-error-boundary": "4.0.13",
     "react-intl": "6.6.5",
     "react-router-dom": "6.22.3",
     "typescript": "5.4.3"

--- a/src/ui/errorBoundary/ErrorBoundary.test.tsx
+++ b/src/ui/errorBoundary/ErrorBoundary.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+
+import { logger } from 'integrations/logger';
+
+import { ErrorBoundary } from './ErrorBoundary';
+
+const logErrorSpy = vitest.spyOn(logger, 'error');
+
+const ErrorComponent = ({ shouldError = true }: { shouldError?: boolean }) => {
+  if (shouldError) {
+    throw new Error('error');
+  }
+  return <div>no error</div>;
+};
+
+describe('ErrorBoundary', () => {
+  it('should show fallback component and log error via logger', () => {
+    render(
+      <ErrorBoundary fallback={<div>error</div>}>
+        <ErrorComponent />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('error')).toBeInTheDocument();
+    expect(logErrorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not log error when shouldLog = false', () => {
+    render(
+      <ErrorBoundary shouldLog={false} fallback={<div>error</div>}>
+        <ErrorComponent />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('error')).toBeInTheDocument();
+    expect(logErrorSpy).not.toBeCalled();
+  });
+
+  it('should show children content when there is no error', () => {
+    render(
+      <ErrorBoundary fallback={<div>error</div>}>
+        <ErrorComponent shouldError={false} />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('no error')).toBeInTheDocument();
+    expect(logErrorSpy).not.toBeCalled();
+  });
+});

--- a/src/ui/errorBoundary/ErrorBoundary.tsx
+++ b/src/ui/errorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,3 @@
+import { ErrorBoundary as ReactErrorBoundary } from 'react-error-boundary';
+
+export const ErrorBoundary = ReactErrorBoundary;

--- a/src/ui/errorBoundary/ErrorBoundary.tsx
+++ b/src/ui/errorBoundary/ErrorBoundary.tsx
@@ -1,3 +1,18 @@
 import { ErrorBoundary as ReactErrorBoundary } from 'react-error-boundary';
+import { ErrorInfo } from 'react';
 
-export const ErrorBoundary = ReactErrorBoundary;
+import { logger } from 'integrations/logger';
+
+import { ErrorBoundaryProps } from './ErrorBoundary.types';
+
+export const ErrorBoundary = ({ shouldLog = true, onError, ...props }: ErrorBoundaryProps) => {
+  const handleError = (error: Error, errorInfo: ErrorInfo) => {
+    if (shouldLog) {
+      logger.error(error);
+    }
+    onError?.(error, errorInfo);
+  };
+
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  return <ReactErrorBoundary onError={handleError} {...props} />;
+};

--- a/src/ui/errorBoundary/ErrorBoundary.types.ts
+++ b/src/ui/errorBoundary/ErrorBoundary.types.ts
@@ -3,6 +3,8 @@ import {
   FallbackProps as ErrorBoundaryFallbackProps,
 } from 'react-error-boundary';
 
-export type ErrorBoundaryProps = ReactErrorBoundaryProps;
+export type ErrorBoundaryProps = ReactErrorBoundaryProps & {
+  shouldLog?: boolean;
+};
 
 export type FallbackProps = ErrorBoundaryFallbackProps;

--- a/src/ui/errorBoundary/ErrorBoundary.types.ts
+++ b/src/ui/errorBoundary/ErrorBoundary.types.ts
@@ -1,0 +1,8 @@
+import {
+  ErrorBoundaryProps as ReactErrorBoundaryProps,
+  FallbackProps as ErrorBoundaryFallbackProps,
+} from 'react-error-boundary';
+
+export type ErrorBoundaryProps = ReactErrorBoundaryProps;
+
+export type FallbackProps = ErrorBoundaryFallbackProps;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: 'src/setupTests.ts',
+    clearMocks: true,
     exclude: [...configDefaults.exclude, 'e2e/**/*', 'e2e-playwright/**/*'],
     coverage: {
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
https://headstart.atlassian.net/browse/ZN-495
Adds a ErrorBoundary component that uses react-error-boundary package.
Added as a separate UI component to make it easier to expand the functionalities of the ErrorBoundary from the package (like sending events to the logger). 