### PR TITLE
fix: fix wdyr issues with hooks order

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,6 @@
-import './wdyr';
+if (import.meta.env.DEV) {
+  import.meta.glob('./wdyr.ts', { eager: true });
+}
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';

--- a/src/wdyr.ts
+++ b/src/wdyr.ts
@@ -1,10 +1,7 @@
 import React from 'react';
+import whyDidYouRender from '@welldone-software/why-did-you-render';
 
-if (import.meta.env.DEV) {
-  const { default: whyDidYouRender } = await import('@welldone-software/why-did-you-render');
-
-  whyDidYouRender(React, {
-    trackHooks: true,
-    trackAllPureComponents: true,
-  });
-}
+whyDidYouRender(React, {
+  trackHooks: true,
+  trackAllPureComponents: true,
+});


### PR DESCRIPTION
![image](https://github.com/TheSoftwareHouse/react-starter-boilerplate/assets/165779447/49ffba45-4534-40a0-b8b9-edb9699366e0)
importing why did you render asynchronously causes some issuew with order of hooks.
Current changes prevents those errors as well as prevents why did you render from being included in production bundle