### PR TITLE
chore: split sentry packages to a dedicated sentry chunk

### DIFF
--- a/.changeset/witty-pans-applaud.md
+++ b/.changeset/witty-pans-applaud.md
@@ -1,0 +1,5 @@
+---
+"react-starter-boilerplate": minor
+---
+
+Split sentry packages to a dedicated sentry chunk

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,12 @@ import svgrPlugin from 'vite-plugin-svgr';
 import { configDefaults } from 'vitest/config';
 import { TanStackRouterVite } from '@tanstack/router-vite-plugin';
 
+const manualChunks = (id: string) => {
+  if (id.includes('@sentry')) {
+    return 'sentry';
+  }
+};
+
 /* eslint-disable import/no-default-export */
 export default defineConfig({
   plugins: [
@@ -21,6 +27,11 @@ export default defineConfig({
   },
   build: {
     outDir: 'build',
+    rollupOptions: {
+      output: {
+        manualChunks,
+      },
+    },
   },
   test: {
     globals: true,


### PR DESCRIPTION
Thanks to moving Sentry (a pretty big dependency) to a separate chunk we gain:
* faster load of the chunks due to loading them in parallel 
* better caching possibility - Such packages are expected to update rarely in the project so if we build them to the separate chunk with a hash based on the content, the hash is persistent between builds in which we have not bumped the version of Sentry, therefore we can make a better use from caching this chunk. 

**Before**

<img width="450" alt="image" src="https://github.com/TheSoftwareHouse/react-starter-boilerplate/assets/26207154/5437a9f1-9592-4e99-b1a9-d2898a267d4f">


**After**

<img width="445" alt="image" src="https://github.com/TheSoftwareHouse/react-starter-boilerplate/assets/26207154/38b4e2d7-c7fa-41ca-9e53-813ac88c3483">
