### PR TITLE
fix: use sentry integrations from @sentry/browser package

### DIFF
--- a/.changeset/stale-peaches-sniff.md
+++ b/.changeset/stale-peaches-sniff.md
@@ -1,0 +1,5 @@
+---
+"react-starter-boilerplate": patch
+---
+
+fix sentry type errors & import integrations from correct package

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.2.0",
       "dependencies": {
         "@sentry/browser": "8.8.0",
-        "@sentry/integrations": "7.110.0",
         "@tanstack/react-query": "5.45.1",
         "@tanstack/react-query-devtools": "5.45.1",
         "@tanstack/react-router": "1.29.2",
@@ -3019,51 +3018,6 @@
       },
       "engines": {
         "node": ">=14.18"
-      }
-    },
-    "node_modules/@sentry/core": {
-      "version": "7.110.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.110.0.tgz",
-      "integrity": "sha512-g4suCQO94mZsKVaAbyD1zLFC5YSuBQCIPHXx9fdgtfoPib7BWjWWePkllkrvsKAv4u8Oq05RfnKOhOMRHpOKqg==",
-      "dependencies": {
-        "@sentry/types": "7.110.0",
-        "@sentry/utils": "7.110.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/integrations": {
-      "version": "7.110.0",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.110.0.tgz",
-      "integrity": "sha512-cWpEGMTyX1XO4jb0NXMh1thkkiSajM5ydE/ceAdxmG9V7gv7E1pREK8P1NeVvzvjZ67z+uVWYbgYwXxd4eqZ/A==",
-      "dependencies": {
-        "@sentry/core": "7.110.0",
-        "@sentry/types": "7.110.0",
-        "@sentry/utils": "7.110.0",
-        "localforage": "^1.8.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/types": {
-      "version": "7.110.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.110.0.tgz",
-      "integrity": "sha512-DqYBLyE8thC5P5MuPn+sj8tL60nCd/f5cerFFPcudn5nJ4Zs1eI6lKlwwyHYTEu5c4KFjCB0qql6kXfwAHmTyA==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/utils": {
-      "version": "7.110.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.110.0.tgz",
-      "integrity": "sha512-VBsdLLN+5tf73fhf/Cm7JIsUJ6y9DkJj8h4I6Mxx0rszrvOyH6S5px40K+V4jdLBzMEvVinC7q2Cbf1YM18BSw==",
-      "dependencies": {
-        "@sentry/types": "7.110.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -9002,11 +8956,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
-    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "dev": true,
@@ -10481,14 +10430,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/lie": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
-      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
-      "dependencies": {
-        "immediate": "~3.0.5"
-      }
-    },
     "node_modules/liftoff": {
       "version": "4.0.0",
       "dev": true,
@@ -10717,14 +10658,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/localforage": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
-      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
-      "dependencies": {
-        "lie": "3.1.1"
       }
     },
     "node_modules/locate-path": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
   },
   "dependencies": {
     "@sentry/browser": "8.8.0",
-    "@sentry/integrations": "7.110.0",
     "@tanstack/react-query": "5.45.1",
     "@tanstack/react-query-devtools": "5.45.1",
     "@tanstack/react-router": "1.29.2",

--- a/src/integrations/logger.ts
+++ b/src/integrations/logger.ts
@@ -1,5 +1,11 @@
-import { init, captureException, captureMessage, browserTracingIntegration } from '@sentry/browser';
-import { httpClientIntegration, captureConsoleIntegration } from '@sentry/integrations';
+import {
+  init,
+  captureException,
+  captureMessage,
+  browserTracingIntegration,
+  httpClientIntegration,
+  captureConsoleIntegration,
+} from '@sentry/browser';
 
 type LogLevel = 'error' | 'info' | 'warning';
 type Logger = Record<LogLevel, (message: string | Error) => void> & Record<string, unknown>;


### PR DESCRIPTION
Upgrading `@sentry/browser` 8.* version caused type errors as sentry team is dropping `@sentry/integrations` package and integrations are now exported from the `@sentry/browser`.

 https://github.com/getsentry/sentry-javascript/releases/tag/8.0.0
 
 We might want to consider adding typecheck to the piplines to pick up these kind of errors in the future