### PR TITLE
fix: regenerate package-lock with a bump of  semver package

### DIFF
--- a/.changeset/orange-wombats-give.md
+++ b/.changeset/orange-wombats-give.md
@@ -1,0 +1,5 @@
+---
+"react-starter-boilerplate": patch
+---
+
+Regenerate lock file with a bigger `semver` package version to satisfy a `npm ci` command

--- a/package-lock.json
+++ b/package-lock.json
@@ -13267,9 +13267,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"


### PR DESCRIPTION
`npm ci` was failing due to trying to install a higher version of `semver`. Regenerating the `package-lock` fixes the issue. 